### PR TITLE
Fix issue setting up site settings in specs

### DIFF
--- a/spec/integration/discourse_slack/slack_spec.rb
+++ b/spec/integration/discourse_slack/slack_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 describe 'Slack' do
-  site_setting("slack_outbound_webhook_url", "https://hooks.slack.com/services/abcde")
-  site_setting("slack_enabled", true)
-  site_setting("post_to_slack_window_secs", 20)
+  before do
+    SiteSetting.slack_outbound_webhook_url = "https://hooks.slack.com/services/abcde"
+    SiteSetting.slack_enabled = true
+    SiteSetting.post_to_slack_window_secs = 20
+  end
 
   let(:first_post) { Fabricate(:post) }
   let(:topic) { Fabricate(:topic, posts: [first_post]) }
@@ -29,7 +31,9 @@ describe 'Slack' do
     end
 
     describe 'when plugin is not enabled' do
-      site_setting(:slack_enabled, false)
+      before do
+        SiteSetting.slack_enabled = false
+      end
 
       it 'should not schedule a job for slack post' do
         Timecop.freeze(Time.zone.now) do

--- a/spec/jobs/notify_slack_spec.rb
+++ b/spec/jobs/notify_slack_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 describe Jobs::NotifySlack do
-  site_setting("slack_outbound_webhook_url", "https://hooks.slack.com/services/abcde")
-  site_setting("slack_enabled", true)
+  before do
+    SiteSetting.slack_outbound_webhook_url = "https://hooks.slack.com/services/abcde"
+    SiteSetting.slack_enabled = true
+  end
 
   before do
     FakeWeb.register_uri(:post, SiteSetting.slack_outbound_webhook_url, :body => "success")


### PR DESCRIPTION
Before this change, I was getting the following error when trying to run the specs for this plugin:

```
$ bundle exec rake plugin:spec["discourse-slack-official"]
...
 `method_missing': undefined method `site_setting' for RSpec::ExampleGroups::Slack:Class (NoMethodError)
```