### PR TITLE
Search with /discourse search {query}

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-slack.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-slack.js.es6
@@ -10,7 +10,8 @@ export default Ember.Controller.extend({
   filters: [
     { id: 'watch', name: I18n.t('slack.future.watch'), icon:'exclamation-circle' },
     { id: 'follow', name: I18n.t('slack.future.follow'), icon: 'circle'},
-    { id: 'mute', name: I18n.t('slack.future.mute'), icon: 'times-circle' }
+    { id: 'mute', name: I18n.t('slack.future.mute'), icon: 'times-circle' },
+    { id: 'search', name: I18n.t('slack.future.search'), icon: 'search' }
   ],
 
   editing: FilterRule.create({}),

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -23,7 +23,9 @@ en:
         mute: 'Muting'
         follow: 'First post only'
         watch: 'All posts and replies'
+        search: 'Searching posts'
       future:
         mute: 'Mute notifications'
         follow: 'Notify of first post'
         watch: 'Notify of all posts and replies'
+        search: 'Searched all related posts'


### PR DESCRIPTION
- Now with search: `/discourse search {query}` 
- Returns top 5 results in public (unlocked) categories
- Message formatted with truncated context that of the post that the query is found in 
- Emoji metadata in the footer for reading time in minutes, # likes, # replies, and timestamp for most recent update of that post
- Search only works on unlocked categories

#1 