### PR TITLE
fix: can't expect post id since it is random

### DIFF
--- a/spec/integration/discourse_slack/slack_spec.rb
+++ b/spec/integration/discourse_slack/slack_spec.rb
@@ -13,7 +13,7 @@ describe 'Slack' do
 
   describe 'testing notification' do
     it 'should ping slack successfully' do
-      DiscourseSlack::Slack.expects(:notify).with(first_post.id)
+      DiscourseSlack::Slack.expects(:notify)
 
       post '/slack/test.json'
 


### PR DESCRIPTION
Since we choose random post to [test](https://github.com/discourse/discourse-slack-official/blob/master/plugin.rb#L74) we can't expect fabricated defined `post_id` [here](https://github.com/discourse/discourse-slack-official/blob/6ca3e0b7f648e5ff9a31dd9c81df339db8abe262/spec/integration/discourse_slack/slack_spec.rb#L16). It gives error.