### PR TITLE
update: 'outbound webhook url' is not required if 'access token' is specified

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,7 +10,7 @@ en:
     post_to_slack_window_secs: 'Wait (n) seconds before posting to slack, to give users a chance to edit and finalize their posts.'
     errors:
       invalid_webhook_url: "'slack outbound webhook url' is not a valid URL."
-      slack_outbound_webhook_url_is_empty: "You must set 'slack outbound webhook url' before enabling this setting."
+      slack_api_configs_are_empty: "You must set 'slack outbound webhook url' or 'slack access token' before enabling this setting."
       slack_discourse_username_is_empty: "You must set 'slack discourse username' before enabling this setting."
   slack:
     message:

--- a/config/locales/server.it.yml
+++ b/config/locales/server.it.yml
@@ -10,7 +10,7 @@ it:
     post_to_slack_window_secs: 'Aspetta (n) secondi prima di pubblicare su slack, per dare agli utenti la possibilità di modificare e finalizzare i loro messaggi.'
     errors:
       invalid_webhook_url: "'slack outbound webhook url' non è un URL valido."
-      slack_outbound_webhook_url_is_empty: "Devi configurare 'slack outbound webhook url' prima di abilitare questa impostazione."
+      slack_api_configs_are_empty: "Devi configurare 'slack outbound webhook url' or 'slack access token' prima di abilitare questa impostazione."
       slack_discourse_username_is_empty: "Devi configurare 'slack discourse username' prima di abilitare questa impostazione."
   slack:
     message:

--- a/lib/validators/discourse_slack_enabled_setting_validator.rb
+++ b/lib/validators/discourse_slack_enabled_setting_validator.rb
@@ -5,14 +5,14 @@ class DiscourseSlackEnabledSettingValidator
 
   def valid_value?(val)
     return true if val == 'f'
-    return false if SiteSetting.slack_outbound_webhook_url.blank? || !valid_webhook_url?
+    return false if (SiteSetting.slack_outbound_webhook_url.blank? || !valid_webhook_url?) && SiteSetting.slack_access_token.blank?
     return false if SiteSetting.slack_discourse_username.blank? || !valid_slack_username?
     true
   end
 
   def error_message
-    if SiteSetting.slack_outbound_webhook_url.blank?
-      I18n.t('site_settings.errors.slack_outbound_webhook_url_is_empty')
+    if SiteSetting.slack_outbound_webhook_url.blank? && SiteSetting.slack_access_token.blank?
+      I18n.t('site_settings.errors.slack_api_configs_are_empty')
     elsif !valid_webhook_url?
       I18n.t('site_settings.errors.invalid_webhook_url')
     elsif SiteSetting.slack_discourse_username.blank?


### PR DESCRIPTION
We already having [methods](https://github.com/discourse/discourse-slack-official/blob/master/lib/discourse_slack/slack.rb#L178-L203) to send message via access token. Should we add RSpec methods to test with access token too? Or can we skip using those API methods with access token.