### PR TITLE
FIX: updating filter for a tag does not impact other tags

### DIFF
--- a/lib/discourse_slack/slack.rb
+++ b/lib/discourse_slack/slack.rb
@@ -120,10 +120,20 @@ module DiscourseSlack
     def self.set_filter_by_id(id, channel, filter, tags = nil, channel_id = nil)
       data = get_store(id)
       tags = Tag.where(name: tags).pluck(:name)
+
+      tags.each do |tag|
+        data.each_with_index do |_, index|
+          data[index]["tags"].delete tag
+        end
+      end
       tags = nil if tags.blank?
 
-      index = data.index do |filter|
-        filter["channel"] == channel || filter["channel"] == channel_id
+      index = data.index do |item|
+        if tags
+          item["filter"] == filter && item["channel"] == channel || item["channel"] == channel_id
+        else
+         item["channel"] == channel || item["channel"] == channel_id
+        end
       end
 
       if index

--- a/spec/integration/discourse_slack/slack_spec.rb
+++ b/spec/integration/discourse_slack/slack_spec.rb
@@ -224,6 +224,31 @@ describe 'Slack', type: :request do
             "tags" => [tag.name, tag_2.name]
           ])
         end
+
+        it 'should update a tag filter correctly' do
+          SiteSetting.tagging_enabled = true
+          tag_2 = Fabricate(:tag)
+
+          post "/slack/command.json",
+            text: "follow tag:#{tag.name}",
+            channel_name: 'welcome',
+            token: token
+
+          post "/slack/command.json",
+            text: "follow tag:#{tag_2.name}",
+            channel_name: 'welcome',
+            token: token
+
+          post "/slack/command.json",
+            text: "watch tag:#{tag.name}",
+            channel_name: 'welcome',
+            token: token
+
+          expect(DiscourseSlack::Slack.get_store).to contain_exactly(
+            {"channel" => "#welcome", "filter" => "follow", "tags" => [tag_2.name]},
+            {"channel" => "#welcome", "filter" => "watch", "tags" => [tag.name]},
+          )
+        end
       end
 
       describe 'mute command' do


### PR DESCRIPTION
This fixes an issue where using the slack command to update the filter for a single tag was changing the notification level for all tags.