### PR TITLE
Unset subscription

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -27,7 +27,7 @@ en:
         with_tags: " with tags *%{tags}*"
       available_categories: "\nHere are your available categories: %{list}"
     help: |
-      `/discourse [watch|follow|mute|help|status] [category|tag:name|all]`
+      `/discourse [watch|follow|mute|unset|help|status] [category|tag:name|all]`
       *watch* – notify this channel for new topics and new replies
       *follow* – notify this channel for new topics
       *mute* – stop notifying this channel

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -32,11 +32,13 @@ en:
       *follow* – notify this channel for new topics
       *mute* – stop notifying this channel
       *status* – show current notification state and categories
+      *unset* – unset a notification state for a tag or category
     command:
       past:
         mute: 'muted'
         follow: 'followed'
         watch: 'watched'
+        unset: 'unset'
       present:
         mute: 'muting'
         follow: 'following'

--- a/lib/discourse_slack/slack.rb
+++ b/lib/discourse_slack/slack.rb
@@ -120,37 +120,35 @@ module DiscourseSlack
     def self.set_filter_by_id(id, channel, filter, tags = nil, channel_id = nil)
       data = get_store(id)
       tags = Tag.where(name: tags).pluck(:name)
-      tags = nil if tags.blank?
-      to_delete = []
 
-      index = data.index do |item|
-        match_channel = item["channel"] == channel || item["channel"] == channel_id
-
-        if item["tags"]
-          if tags
-            item["tags"] = item["tags"] - tags
-
-            if item["tags"].blank?
-              to_delete << item
-              next
+      tags.each do |tag|
+        data.each_with_index do |item, index|
+          if data[index]["tags"].include? tag 
+            if  data[index]["tags"].size == 1
+              data.delete item
+            else
+              data[index]["tags"].delete tag
             end
           end
+        end
+      end
+      tags = nil if tags.blank?
 
-          item["filter"] == filter && match_channel
+      index = data.index do |item|
+        if tags
+          item["tags"] && item["filter"] == filter && (item["channel"] == channel || item["channel"] == channel_id)
         else
-          match_channel
+          !item["tags"] && (item["channel"] == channel || item["channel"] == channel_id)
         end
       end
 
       if index
         data[index]['filter'] = filter
         data[index]['channel'] = channel
-        data[index]['tags'] = data[index]['tags'].concat(tags).uniq if tags
+        data[index]['tags'] = data[index]['tags'].concat(tags).uniq
       else
         data.push(channel: channel, filter: filter, tags: tags)
       end
-
-      data = data - to_delete
 
       PluginStore.set(DiscourseSlack::PLUGIN_NAME, get_key(id), data)
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -82,10 +82,10 @@ after_initialize do
       render json: success_json
     end
 
-    def edit
+    def create
       params.permit(:tags, :category_id, :filter, :channel)
 
-      DiscourseSlack::Slack.set_filter_by_id(params[:category_id], params[:channel], params[:filter], params[:tags])
+      DiscourseSlack::Slack.create_filter(params[:category_id], params[:channel], params[:filter], params[:tags])
       render json: success_json
     end
 
@@ -128,15 +128,15 @@ after_initialize do
               if !tag
                 I18n.t("slack.message.not_found.tag", name: value)
               else
-                DiscourseSlack::Slack.set_filter_by_id(nil, channel, cmd, [tag.name], params[:channel_id])
+                DiscourseSlack::Slack.update_tag_filter(channel, cmd, tag.name)
                 I18n.t("slack.message.success.tag", command: filter_to_past, name: tag.name)
               end
             else
               if (value.casecmp("all") == 0)
-                DiscourseSlack::Slack.set_filter_by_id(nil, channel, cmd, nil, params[:channel_id])
+                DiscourseSlack::Slack.update_all_filter(channel, cmd)
                 I18n.t("slack.message.success.all_categories", command: filter_to_past)
               elsif (category = Category.find_by(slug: value)) && guardian.can_see_category?(category)
-                DiscourseSlack::Slack.set_filter_by_id(category.id, channel, cmd, nil, params[:channel_id])
+                DiscourseSlack::Slack.update_category_filter(channel, cmd, category.id)
                 I18n.t("slack.message.success.category", command: filter_to_past, name: category.name)
               else
                 cat_list = (CategoryList.new(guardian).categories.map(&:slug)).join(', ')
@@ -203,7 +203,7 @@ after_initialize do
     get "/list" => "slack#list", constraints: AdminConstraint.new
     put "/test" => "slack#test_notification", constraints: AdminConstraint.new
     put "/reset_settings" => "slack#reset_settings", constraints: AdminConstraint.new
-    put "/list" => "slack#edit", constraints: AdminConstraint.new
+    put "/list" => "slack#create", constraints: AdminConstraint.new
     delete "/list" => "slack#delete", constraints: AdminConstraint.new
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -116,7 +116,7 @@ after_initialize do
 
       text =
         case cmd
-        when "watch", "follow", "mute"
+        when "watch", "follow", "mute", "unset"
           if (tokens.size == 2)
             value = tokens[1]
             filter_to_past = DiscourseSlack::Slack.filter_to_past(cmd).capitalize

--- a/spec/integration/discourse_slack/slack_spec.rb
+++ b/spec/integration/discourse_slack/slack_spec.rb
@@ -36,7 +36,7 @@ describe 'Slack', type: :request do
       end
 
       it 'should return the right response' do
-        DiscourseSlack::Slack.set_filter_by_id(category.id, '#some', 'follow', [tag.name])
+        DiscourseSlack::Slack.update_filter(category.id, '#some', 'follow', [tag.name])
 
         get '/slack/list.json'
 
@@ -99,7 +99,7 @@ describe 'Slack', type: :request do
       end
 
       it 'should be able to delete a filter' do
-        DiscourseSlack::Slack.set_filter_by_id(category.id, '#some', 'follow', [tag.name])
+        DiscourseSlack::Slack.update_filter(category.id, '#some', 'follow', [tag.name])
 
         delete '/slack/list.json',
           category_id: category.id,

--- a/spec/jobs/notify_slack_spec.rb
+++ b/spec/jobs/notify_slack_spec.rb
@@ -20,7 +20,7 @@ describe Jobs::NotifySlack do
       response = Jobs::NotifySlack.new.execute(post_id: post.id)
       expect(response[0]).to eq(nil)
 
-      DiscourseSlack::Slack.set_filter_by_id(category.id, "#general", "follow")
+      DiscourseSlack::Slack.create_filter(category.id, "#general", "follow", nil)
       response = Jobs::NotifySlack.new.execute(post_id: post.id)
 
       expect(response[0]).to eq("success")
@@ -34,7 +34,7 @@ describe Jobs::NotifySlack do
       response = Jobs::NotifySlack.new.execute(post_id: post.id)
       expect(response[0]).to eq(nil)
 
-      DiscourseSlack::Slack.set_filter_by_id(nil, "#general", "follow", [tag.name])
+      DiscourseSlack::Slack.create_filter(nil, "#general", "follow", [tag.name])
       response = Jobs::NotifySlack.new.execute(post_id: post.id)
 
       expect(response[0]).to eq("success")
@@ -47,7 +47,7 @@ describe Jobs::NotifySlack do
       user = Fabricate(:user)
 
       SiteSetting.slack_discourse_username = user.username
-      DiscourseSlack::Slack.set_filter_by_id(nil, "#general", "follow")
+      DiscourseSlack::Slack.create_filter(nil, "#general", "follow", nil)
 
       response = Jobs::NotifySlack.new.execute(post_id: post.id)
       expect(response).to eq(nil)


### PR DESCRIPTION
Add ability to unset a subscription via a slack command:
https://meta.discourse.org/t/slack-command-to-un-watch-follow-mute-tag-or-category/60707


To unset a filter for a category:

`/discourse unset foo_category`

To unset a filter for a tag:

`/discourse unset tag:foo`

Note: This PR also includes the changes from the following open PRs:

- https://github.com/discourse/discourse-slack-official/pull/35
- https://github.com/discourse/discourse-slack-official/pull/37